### PR TITLE
Update Home Assistant version and add hide_default_branch

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,7 @@
   "content_in_root": false,
   "filename": "torque_obd",
   "render_readme": true,
-  "homeassistant": "2023.1.0"
+  "homeassistant": "2025.11.0",
+  "hide_default_branch": true
 }
+


### PR DESCRIPTION
This pull request makes a couple of minor configuration updates to the `hacs.json` file, primarily updating compatibility requirements and adjusting repository visibility settings.

Configuration updates:

* Increased the minimum required Home Assistant version to `2025.11.0`, ensuring compatibility with newer releases.
* Added the `hide_default_branch` flag, which will hide the default branch in HACS.